### PR TITLE
Take into account filters (suite and platform) also when the artifacts directory already exists

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -56,19 +56,15 @@ class Test(unittest.TestCase):
         self.assertTrue(os.path.exists('ccov-artifacts/%s_target.txt' % task_id))
         os.remove('ccov-artifacts/%s_target.txt' % task_id)
 
-        codecoverage.download_coverage_artifacts(task_id, 'cppunit', None, 'ccov-artifacts')
+        artifact_paths = codecoverage.download_coverage_artifacts(task_id, 'cppunit', None, 'ccov-artifacts')
         self.assertEqual(len([a for a in os.listdir('ccov-artifacts') if 'grcov' in a]), 2)
         self.assertEqual(len([a for a in os.listdir('ccov-artifacts') if 'jsvm' in a]), 2)
+        self.assertEqual(len([a for a in artifact_paths if 'grcov' in a]), 2)
+        self.assertEqual(len([a for a in artifact_paths if 'jsvm' in a]), 2)
 
         codecoverage.download_grcov()
-        codecoverage.generate_report('./grcov', 'lcov', 'output.info', 'ccov-artifacts')
+        codecoverage.generate_report('./grcov', 'lcov', 'output.info', artifact_paths)
         self.assertTrue(os.path.exists('output.info'))
-
-        # Remove all artifacts except one to make the genhtml pass faster for the test.
-        for a in os.listdir('ccov-artifacts'):
-            if 'jsvm' in a:
-                os.remove(os.path.join('ccov-artifacts', a))
-        os.remove(os.path.join('ccov-artifacts', os.listdir('ccov-artifacts')[0]))
 
         codecoverage.download_genhtml()
         codecoverage.generate_html_report('tests', silent=True)


### PR DESCRIPTION
Without this patch, the filters are not taken into account if you already have unrelated artifacts in a directory.